### PR TITLE
Removing Horizontal Nav Bar - Issue #49

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2,6 +2,7 @@ body,
 html {
     height: 100vh;
     width: 100vw;
+    overflow-x: hidden;
 }
 
 .box {


### PR DESCRIPTION
Added the overflow-x: hidden attribute to remove the horizontal scroll bar that some users were getting when viewing the site. 